### PR TITLE
feat: Option to skip with transformFunction

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Upload Lambda to AWS and _star_ this repository if it works as expected!!
 | index  | The name of ElasticSearch index (string). If not provided will set the same as DynamoDB table name | optional
 | type  | The type of the ElasticSearch document (string). If not provided will set the same as DynamoDB table name | optional
 | refresh  | Force ElasticSearch refresh its index immediately [more here](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-refresh.html) (boolean). Default: true | optional
-| transformFunction  | A function/promise to transform each record before sending them to ES. Applies to INSERT and UPDATE operations | optional
+| transformFunction  | A function/promise to transform each record before sending them to ES. Applies to INSERT and UPDATE operations. If transformFunction returns an empty object or false the index will be skipped. | optional
 | elasticSearchOptions  | Additional set of arguments passed to elasticsearch Client see [here](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/16.x/configuration.html#config-options) | optional
 
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Upload Lambda to AWS and _star_ this repository if it works as expected!!
 | index  | The name of ElasticSearch index (string). If not provided will set the same as DynamoDB table name | optional
 | type  | The type of the ElasticSearch document (string). If not provided will set the same as DynamoDB table name | optional
 | refresh  | Force ElasticSearch refresh its index immediately [more here](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-refresh.html) (boolean). Default: true | optional
-| transformFunction  | A function/promise to transform each record before sending them to ES. Applies to INSERT and UPDATE operations. If transformFunction returns an empty object or false the index will be skipped. | optional
+| transformFunction  | A function/promise to transform each record before sending them to ES. Applies to INSERT and UPDATE operations. If transformFunction returns an empty object or false the row will be skipped. | optional
 | elasticSearchOptions  | Additional set of arguments passed to elasticsearch Client see [here](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/16.x/configuration.html#config-options) | optional
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -56,8 +56,11 @@ exports.pushStream = async (
           body = await Promise.resolve(transformFunction(body))
         }
         try {
-          if (body) {
-            await es.index({ index, type, id, body, refresh })
+          if (
+            body &&
+            (Object.keys(body).length !== 0 && body.constructor === Object)
+          ) {
+            await es.index({ index, type, id, body, refresh });
           }
         } catch (e) {
           throw new Error(e)

--- a/src/index.js
+++ b/src/index.js
@@ -56,7 +56,9 @@ exports.pushStream = async (
           body = await Promise.resolve(transformFunction(body))
         }
         try {
-          await es.index({ index, type, id, body, refresh })
+          if (body) {
+            await es.index({ index, type, id, body, refresh })
+          }
         } catch (e) {
           throw new Error(e)
         }

--- a/test/index.js
+++ b/test/index.js
@@ -291,7 +291,7 @@ describe('Test stream events', () => {
     await assertThrowsAsync(async () => pushStream(simpleData), 'Please provide correct value for transformFunction')
   })
 
-  it('Input data: should skip index if body is empty', async () => {
+  it('Input data: should skip index if body is false', async () => {
     await pushStream({
       event: insertEvent,
       index: INDEX,
@@ -305,6 +305,21 @@ describe('Test stream events', () => {
     body = await result.json()
     assert.isFalse(body.found)
   })
+
+  it('Input data: should skip index if body is empty', async () => {
+    await pushStream({
+      event: insertEvent,
+      index: INDEX,
+      type: TYPE,
+      endpoint: ES_ENDPOINT,
+      transformFunction: body => {},
+      testMode: true
+    });
+    const inserted = converter(insertEvent.Records[0].dynamodb.Keys).url;
+    result = await fetch(`http://${ES_ENDPOINT}/${INDEX}/${TYPE}/${inserted}`);
+    body = await result.json();
+    assert.isFalse(body.found);
+  });
 
   it('INSERT: should insert new item based on elasticSearchOptions ', async () => {
     await pushStream({

--- a/test/index.js
+++ b/test/index.js
@@ -291,6 +291,21 @@ describe('Test stream events', () => {
     await assertThrowsAsync(async () => pushStream(simpleData), 'Please provide correct value for transformFunction')
   })
 
+  it('Input data: should skip index if body is empty', async () => {
+    await pushStream({
+      event: insertEvent,
+      index: INDEX,
+      type: TYPE,
+      endpoint: ES_ENDPOINT,
+      transformFunction: (body) => false,
+      testMode: true
+    })
+    const inserted = converter(insertEvent.Records[0].dynamodb.Keys).url
+    result = await fetch(`http://${ES_ENDPOINT}/${INDEX}/${TYPE}/${inserted}`)
+    body = await result.json()
+    assert.isFalse(body.found)
+  })
+
   it('INSERT: should insert new item based on elasticSearchOptions ', async () => {
     await pushStream({
       event: insertEvent,


### PR DESCRIPTION
This pull request adds a simple if-statement before running `es.index`.

With this, you can skip records with returning `false` in the transform function.