### PR TITLE
Upgrade to @elastic/elasticsearch

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "node-fetch": "^2.6.0"
   },
   "dependencies": {
-    "aws-sdk": "^2.469.0",
-    "elasticsearch": "^15.5.0",
-    "http-aws-es": "^6.0.0"
+    "@acuris/aws-es-connection": "^1.0.1",
+    "@elastic/elasticsearch": "^7.4.0",
+    "aws-sdk": "^2.469.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,7 @@ exports.pushStream = async (
   validateBoolean(refresh, 'refresh')
   validateFunctionOrUndefined(transformFunction, 'transformFunction')
 
-  const es = elastic(endpoint, testMode, elasticSearchOptions)
+  const es = await elastic(endpoint, testMode, elasticSearchOptions)
 
   for (const record of event.Records) {
     const keys = converter(record.dynamodb.Keys)
@@ -40,7 +40,7 @@ exports.pushStream = async (
     switch (record.eventName) {
       case 'REMOVE': {
         try {
-          if (await es.exists({ index, type, id, refresh })) {
+          if ((await es.exists({ index, type, id, refresh })).body) {
             await es.remove({ index, type, id, refresh })
           }
         } catch (e) {

--- a/src/utils/es-wrapper.js
+++ b/src/utils/es-wrapper.js
@@ -17,29 +17,9 @@ module.exports = async (node, testMode, options) => {
   })
 
   return {
-    index: ({ index, type, id, body, refresh }) => new Promise((resolve, reject) => {
-      es.index({ index, type, id, body, refresh, timeout: '5m' }, (error, response) => {
-        if (error) reject(error)
-        resolve(response)
-      })
-    }),
-    remove: ({ index, type, id, refresh }) => new Promise((resolve, reject) => {
-      es.delete({ index, type, id, refresh }, (error, response) => {
-        if (error) reject(error)
-        resolve(response)
-      })
-    }),
-    exists: ({ index, type, id, refresh }) => new Promise((resolve, reject) => {
-      es.exists({ index, type, id, refresh }, (error, response) => {
-        if (error) reject(error)
-        resolve(response)
-      })
-    }),
-    indicesDelete: (index = '_all') => new Promise((resolve, reject) => {
-      es.indices.delete({ index }, (error, response) => {
-        if (error) reject(error)
-        resolve(response)
-      })
-    })
+    index: ({ index, type, id, body, refresh }) => es.index({ index, type, id, body, refresh, timeout: '5m' }),
+    remove: ({ index, type, id, refresh }) => es.delete({ index, type, id, refresh }),
+    exists: ({ index, type, id, refresh }) => es.exists({ index, type, id, refresh }),
+    indicesDelete: (index = '_all') => es.indices.delete({ index })
   }
 }

--- a/src/utils/es-wrapper.js
+++ b/src/utils/es-wrapper.js
@@ -2,7 +2,6 @@ const { Client } = require('@elastic/elasticsearch')
 const { createAWSConnection, awsGetCredentials } = require('@acuris/aws-es-connection')
 
 module.exports = async (node, testMode, options) => {
-
   const esParams = { node }
   // Because we use ordinary elasticsearch container instead of AWS elasticsearch for integration tests
   // then if endpoint is localhost we cannot upload aws credentials


### PR DESCRIPTION
Hi, I upgraded to the new official elasticsearch client. I tried to keep the same interface for `pushStream`. 

One minor breaking change:

* `endpoint` requires the protocol. The underlying client needs it. We could add one when we build the request, but I do not know how to decide between `http` and `https`. Thus, I thought that the library user should know it better than us.

I used elastic search client `7.4.x`, which should be compatible with elasticsearch 7.4. Do we want to support also older versions?

Let me know if you need changes.