### PR TITLE
Remove new Error() wrapper

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,7 @@ exports.pushStream = async (
             await es.remove({ index, type, id, refresh })
           }
         } catch (e) {
-          throw new Error(e)
+          throw e
         }
         break
       }
@@ -64,7 +64,7 @@ exports.pushStream = async (
             await es.index({ index, type, id, body, refresh })
           }
         } catch (e) {
-          throw new Error(e)
+          throw e
         }
         break
       }


### PR DESCRIPTION
Wrapping the error into another error is causing loss of important information: context info and, reason.

With the Error constructor:
```
{
    "errorType": "Error",
    "errorMessage": "Error Error: ResponseError: illegal_argument_exception",
    "stack": [
        "Error: Error Error: ResponseError: illegal_argument_exception",
        "    at _homogeneousError (/var/runtime/CallbackContext.js:13:12)",
        "    at postError (/var/runtime/CallbackContext.js:30:54)",
        "    at callback (/var/runtime/CallbackContext.js:42:7)",
        "    at /var/runtime/CallbackContext.js:105:16",
        "    at /var/task/DynamoToES.js:15:9",
        "    at processTicksAndRejections (internal/process/task_queues.js:97:5)"
    ]
}
```

Without the Error constructor:
```
{
    "errorType": "ResponseError",
    "errorMessage": "illegal_argument_exception",
    "name": "ResponseError",
    "meta": {
        "body": {
            "error": {
                "root_cause": [
                    {
                        "type": "illegal_argument_exception",
                        "reason": "Rejecting mapping update to [...] as the final mapping would have more than 1 type: [_doc, ...]"
                    }
                ],
                "type": "illegal_argument_exception",
                "reason": "Rejecting mapping update to [...] as the final mapping would have more than 1 type: [_doc, ...]"
            },
            "status": 400
        },
        "statusCode": 400,
        "headers": {
            "date": "Sat, 11 Apr 2020 13:53:27 GMT",
            "content-type": "application/json; charset=UTF-8",
            "content-length": "347",
            "connection": "keep-alive",
            "access-control-allow-origin": "*"
        },
        "warnings": null,
        "meta": {
            "context": null,
            "request": {
                "params": {
                    "method": "PUT",
                    "path": "...",
                    "body": "{...}",
                    "querystring": "refresh=true&timeout=5m",
                    "headers": {
                        "User-Agent": "elasticsearch-js/7.6.1 (linux 4.14.165-102.205.amzn2.x86_64-x64; Node.js v12.16.1)",
                        "Content-Type": "application/json",
                        "Content-Length": "2237"
                    },
                    "timeout": 30000
                },
                "options": {
                    "warnings": null
                },
                "id": 1
            },
            "name": "elasticsearch-js",
            "connection": { ... },
            "attempts": 0,
            "aborted": false
        }
    },
    "stack": [
        "ResponseError: illegal_argument_exception",
        "    at IncomingMessage.<anonymous> (/var/task/node_modules/@elastic/elasticsearch/lib/Transport.js:296:25)",
        "    at IncomingMessage.emit (events.js:323:22)",
        "    at IncomingMessage.EventEmitter.emit (domain.js:482:12)",
        "    at endReadableNT (_stream_readable.js:1204:12)",
        "    at processTicksAndRejections (internal/process/task_queues.js:84:21)"
    ]
}
```

If you don't want to show all of this information, the library should at least return the reason in the error.