### PR TITLE
tests passing; feature done: es batch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,18 @@
 language: node_js
 node_js:
   - 10
-services:
-  - elasticsearch
 before_script:
   - sleep 20
 cache: npm
 script:
   - npm run lint
   - npm run test
+before_install:
+  - curl -s -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.7.1-amd64.deb
+  - sudo dpkg -i --force-confnew elasticsearch-7.7.1-amd64.deb
+  - sudo sed -i.old 's/-Xms1g/-Xms128m/' /etc/elasticsearch/jvm.options
+  - sudo sed -i.old 's/-Xmx1g/-Xmx128m/' /etc/elasticsearch/jvm.options
+  - echo -e '-XX:+DisableExplicitGC\n-Djdk.io.permissionsUseCanonicalPath=true\n-Dlog4j.skipJansi=true\n-server\n' | sudo tee -a /etc/elasticsearch/jvm.options
+  - sudo chown -R elasticsearch:elasticsearch /etc/default/elasticsearch
+  - sudo systemctl start elasticsearch
+  - sleep 10

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
   "dependencies": {
     "@acuris/aws-es-connection": "^1.0.1",
     "@elastic/elasticsearch": "^7.6.1",
-    "aws-sdk": "^2.642.0"
+    "aws-sdk": "^2.642.0",
+    "lodash.flatmap": "^4.5.0"
   },
   "typings": "./src/index.d.ts"
 }

--- a/src/utils/es-wrapper.js
+++ b/src/utils/es-wrapper.js
@@ -20,6 +20,7 @@ module.exports = async (node, testMode, options) => {
     index: ({ index, type, id, body, refresh }) => es.index({ index, type, id, body, refresh, timeout: '5m' }),
     remove: ({ index, type, id, refresh }) => es.delete({ index, type, id, refresh }),
     exists: ({ index, type, id, refresh }) => es.exists({ index, type, id, refresh }),
-    indicesDelete: (index = '_all') => es.indices.delete({ index })
+    indicesDelete: (index = '_all') => es.indices.delete({ index }),
+    bulk: ({ refresh = true, body }) => es.bulk({ refresh, body })
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -204,6 +204,26 @@ describe('Test stream events', () => {
     assert.deepEqual(data, body._source)
   })
 
+  it('Multiple events: insert, remove, modify using bulk option', async () => {
+    await pushStream({ event: multipleEvents, index: INDEX, type: TYPE, endpoint: ES_ENDPOINT, useBulk: true, testMode: true })
+    const removed = converter(multipleEvents.Records[2].dynamodb.Keys).url
+    const inserted = converter(multipleEvents.Records[0].dynamodb.Keys).url
+    const changed = converter(multipleEvents.Records[1].dynamodb.Keys).url
+    // REMOVED
+    let result = await fetch(`${ES_ENDPOINT}/${INDEX}/${TYPE}/${removed}`)
+    let body = await result.json()
+    assert.isFalse(body.found)
+    // INSERTED
+    result = await fetch(`${ES_ENDPOINT}/${INDEX}/${TYPE}/${inserted}`)
+    body = await result.json()
+    assert.isTrue(body.found)
+    // CHANGED
+    result = await fetch(`${ES_ENDPOINT}/${INDEX}/${TYPE}/${changed}`)
+    body = await result.json()
+    const data = removeEventData(converter(multipleEvents.Records[1].dynamodb.NewImage))
+    assert.deepEqual(data, body._source)
+  })
+
   it('Multiple events: insert, remove, modify with refresh false', async () => {
     await pushStream({
       event: multipleEvents,
@@ -212,6 +232,34 @@ describe('Test stream events', () => {
       endpoint: ES_ENDPOINT,
       testMode: true,
       refresh: false
+    })
+    const removed = converter(multipleEvents.Records[2].dynamodb.Keys).url
+    const inserted = converter(multipleEvents.Records[0].dynamodb.Keys).url
+    const changed = converter(multipleEvents.Records[1].dynamodb.Keys).url
+    // REMOVED
+    let result = await fetch(`${ES_ENDPOINT}/${INDEX}/${TYPE}/${removed}`)
+    let body = await result.json()
+    assert.isFalse(body.found)
+    // INSERTED
+    result = await fetch(`${ES_ENDPOINT}/${INDEX}/${TYPE}/${inserted}`)
+    body = await result.json()
+    assert.isTrue(body.found)
+    // CHANGED
+    result = await fetch(`${ES_ENDPOINT}/${INDEX}/${TYPE}/${changed}`)
+    body = await result.json()
+    const data = removeEventData(converter(multipleEvents.Records[1].dynamodb.NewImage))
+    assert.deepEqual(data, body._source)
+  })
+
+  it('Multiple events: insert, remove, modify with refresh false using bulk', async () => {
+    await pushStream({
+      event: multipleEvents,
+      index: INDEX,
+      type: TYPE,
+      endpoint: ES_ENDPOINT,
+      testMode: true,
+      refresh: false,
+      useBulk: true
     })
     const removed = converter(multipleEvents.Records[2].dynamodb.Keys).url
     const inserted = converter(multipleEvents.Records[0].dynamodb.Keys).url


### PR DESCRIPTION
Hi @matrus2 first of all thanks for the awesome library, I've been using this pattern for a couple of years, and two years ago either this lib wasn't around or I didn't find it so we built out own solution. 

But right now we are using it in production with good results. 

I thought about implementing the ES BATCH inserts, as we have a lot of data. 

The changes are pretty simple, it just took me forever to figure out the rather awkward API of elasticsearch.js for this.  (see also this discussion https://github.com/elastic/elasticsearch-js/issues/1200) 

One thing to note is that it will always refresh now, but it's only one refresh per batch. 

Tests are passing, let me know if you like it or you want to change anything else. 

Thanks & Keep the good work! 

Antonio