### PR TITLE
Fix Typescript declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
   },
   "homepage": "https://github.com/matrus2/dynamodb-stream-elasticsearch#readme",
   "devDependencies": {
+    "@types/aws-lambda": "^8.10.83",
+    "aws-lambda": "^1.0.6",
+    "aws-sdk": "2.*.*",
     "chai": "^4.3.4",
     "chai-spies": "^1.0.0",
     "eslint": "^7.31.0",
@@ -47,8 +50,7 @@
     "mocha": "^9.0.2",
     "node-fetch": "^2.6.1",
     "prettier": "^2.3.2",
-    "typescript": "^4.3.5",
-    "aws-sdk": "2.*.*"
+    "typescript": "^4.3.5"
   },
   "dependencies": {
     "@elastic/elasticsearch": "7.13.0",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,12 +1,13 @@
 import { ClientOptions } from "@elastic/elasticsearch";
-import { RecordList, Record, AttributeMap } from "aws-sdk/clients/dynamodbstreams";
+import { DynamoDBStreamEvent, DynamoDBRecord  } from 'aws-lambda';
+import { AttributeMap } from "aws-sdk/clients/dynamodbstreams";
 
 export function pushStream(opts: streamOptions): Promise<void>
 
-export type transformFunction = (body?: { [key: string]: any }, oldBody?: AttributeMap, record?: Record) => Promise<any> | any
+export type transformFunction = (body?: { [key: string]: any }, oldBody?: AttributeMap, record?: DynamoDBRecord) => Promise<any> | any
 
 export interface streamOptions {
-    event: RecordList,
+    event: DynamoDBStreamEvent,
     index?: string,
     type?: string,
     endpoint: string,


### PR DESCRIPTION
hello,

The declaration file typed the `event` as a `RecordList`, but a stream event is an object with a Records property that has the array.

Also, the `Record` type from the `aws-sdk` doesn't have the `eventSourceARN` property that is used in the code, so I changed that to `DynamoDBRecord`.

I needed to install the `aws-lambda` package to use its types in these cases.