### PR TITLE
fix: doc not being deleted properly

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -89,24 +89,6 @@ exports.pushStream = async (
     }
   }
 
-  if (toRemove.length > 0) {
-    if (useBulk === true) {
-      const bodyDelete = flatMap(toRemove, (doc) => [{ delete: { _index: doc.index, _id: doc.id } }])
-      const { body: bulkResponse } = await es.bulk({ refresh: toRemove[0].refresh, body: bodyDelete })
-      if (bulkResponse.errors) {
-        handleBulkResponseErrors(bulkResponse, bodyDelete)
-      }
-    } else {
-      for (const doc of toRemove) {
-        const { index, id, refresh } = doc
-        const { body: exists } = await es.exists({ index, id, refresh })
-        if (exists) {
-          await es.remove({ index, id, refresh })
-        }
-      }
-    }
-  }
-
   if (toUpsert.length > 0) {
     if (useBulk === true) {
       const updateBody = flatMap(toUpsert, (doc) => [
@@ -121,6 +103,24 @@ exports.pushStream = async (
       for (const doc of toUpsert) {
         const { index, id, body, refresh } = doc
         await es.index({ index, id, body, refresh })
+      }
+    }
+  }
+
+  if (toRemove.length > 0) {
+    if (useBulk === true) {
+      const bodyDelete = flatMap(toRemove, (doc) => [{ delete: { _index: doc.index, _id: doc.id } }])
+      const { body: bulkResponse } = await es.bulk({ refresh: toRemove[0].refresh, body: bodyDelete })
+      if (bulkResponse.errors) {
+        handleBulkResponseErrors(bulkResponse, bodyDelete)
+      }
+    } else {
+      for (const doc of toRemove) {
+        const { index, id, refresh } = doc
+        const { body: exists } = await es.exists({ index, id, refresh })
+        if (exists) {
+          await es.remove({ index, id, refresh })
+        }
       }
     }
   }


### PR DESCRIPTION
We were running into an issue where items are not being removed from ES Index properly. So hence we are getting a bunch of "ghost" documents that has no matching item in DynamoDB.

It turns out that because sometimes the DDB Stream places an update and removal in the same call to the lambda function, It is performing the deletion and then an update afterwards which puts it back in.

So reversing the order of upsert-ing first and then removal solves the issue.