### PR TITLE
Add option for keep alive to avoid exhausting file descriptors

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Upload Lambda to AWS and _star_ this repository if it works as expected!!
 | index  | The name of Elasticsearch index (string). If not provided will set the same as DynamoDB table name | optional
 | refresh  | Force Elasticsearch refresh its index immediately [more here](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-refresh.html) (boolean). Default: true | optional
 | useBulk  | Enables bulk upserts and removals (boolean). Default: false | optional
+| keepAlive  | Keep sockets around in a pool to be used by other requests in the future (boolean). Default = false | optional
 | transformFunction  | A function/promise to transform each record before sending them to ES. Applies to INSERT and UPDATE operations. If transformFunction returns an empty object or false the row will be skipped. This function will receive `body` (NewImage), `oldBody` (OldImage) and (record) as the whole record as arguments. | optional
 | elasticSearchOptions  | Additional set of arguments passed to elasticsearch Client see [here](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/16.x/configuration.html#config-options) | optional
 

--- a/src/index.js
+++ b/src/index.js
@@ -41,6 +41,7 @@ exports.pushStream = async (
     endpoint,
     refresh = true,
     useBulk = false,
+    keepAlive = false,
     transformFunction = undefined,
     elasticSearchOptions
   } = {}) => {
@@ -48,9 +49,10 @@ exports.pushStream = async (
   validateString(endpoint, 'endpoint')
   validateBoolean(refresh, 'refresh')
   validateBoolean(useBulk, 'useBulk')
+  validateBoolean(keepAlive, 'keepAlive')
   validateFunctionOrUndefined(transformFunction, 'transformFunction')
 
-  const es = await elastic(endpoint, elasticSearchOptions)
+  const es = await elastic(endpoint, elasticSearchOptions, keepAlive)
 
   const toRemove = []
   const toUpsert = []

--- a/src/utils/es-wrapper.js
+++ b/src/utils/es-wrapper.js
@@ -1,12 +1,12 @@
 const { Client } = require('@elastic/elasticsearch')
 const { createAWSConnection, awsGetCredentials } = require('./aws-es-connection')
 
-module.exports = async (node, options) => {
+module.exports = async (node, options, keepAlive) => {
   const esParams = { node }
   let AWSConnection = {}
 
   const awsCredentials = await awsGetCredentials()
-  AWSConnection = createAWSConnection(awsCredentials)
+  AWSConnection = createAWSConnection(awsCredentials, keepAlive)
 
   const es = new Client({
     ...AWSConnection,

--- a/test/index.js
+++ b/test/index.js
@@ -174,6 +174,20 @@ describe('Test stream events', () => {
     assert.deepEqual(data, body._source)
   })
 
+  it('Insert: should insert new item with keep alive', async () => {
+    await pushStream({
+      event: insertEvent,
+      index: INDEX,
+      endpoint: ES_ENDPOINT,
+      keepAlive: true
+    })
+    const inserted = converter(insertEvent.Records[0].dynamodb.Keys).url
+    // INSERTED
+    let result = await fetch(`${ES_ENDPOINT}/${INDEX}/_doc/${inserted}`)
+    let body = await result.json()
+    assert.isTrue(body.found)
+  })
+
   it('Multiple events: insert, remove, modify', async () => {
     await pushStream({ event: multipleEvents, index: INDEX, endpoint: ES_ENDPOINT })
     const removed = converter(multipleEvents.Records[2].dynamodb.Keys).url


### PR DESCRIPTION
Option for keep alive for node http, going to help with performance and not exhausting file descriptors on heavy load.