### PR TITLE
Update index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -102,9 +102,17 @@ exports.pushStream = async (
         handleBulkResponseErrors(bulkResponse, updateBody)
       }
     } else {
+      let error;
       for (const doc of toUpsert) {
         const { index, id, body, refresh } = doc
-        await es.index({ index, id, body, refresh })
+        try {
+          await es.index({ index, id, body, refresh })
+        } catch (e) {
+          error = e;
+        }
+      }
+      if(error){
+        throw error;
       }
     }
   }
@@ -117,12 +125,20 @@ exports.pushStream = async (
         handleBulkResponseErrors(bulkResponse, bodyDelete)
       }
     } else {
+      let error;
       for (const doc of toRemove) {
         const { index, id, refresh } = doc
         const { body: exists } = await es.exists({ index, id, refresh })
         if (exists) {
-          await es.remove({ index, id, refresh })
+          try {
+            await es.remove({ index, id, refresh })
+          } catch (e) {
+            error = e;
+          }
         }
+      }
+      if(error) {
+        throw error;
       }
     }
   }


### PR DESCRIPTION
Prevent that an error on a specific document affects other documents. Ideally we should throw an erro that contains all the errors and related docs. But I kept it returning a single error for contract compatibility.